### PR TITLE
Main function was not being exported properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-exports = function(x) {
+module.exports = function(x) {
   throw x;
 };


### PR DESCRIPTION
Writing `exports =` creates a new exports object, but keeps the empty one intact. To actually set exports to a function, you have to write `module.exports =`.